### PR TITLE
Make customer taxable flag a pointer

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -36,7 +36,7 @@ type Customer struct {
 	PrimaryEmailAddr   *EmailAddress   `json:",omitempty"`
 	WebAddr            *WebSiteAddress `json:",omitempty"`
 	//DefaultTaxCodeRef
-	Taxable              bool             `json:",omitempty"`
+	Taxable              *bool            `json:",omitempty"`
 	TaxExemptionReasonID string           `json:"TaxExemptionReasonId,omitempty"`
 	BillAddr             *PhysicalAddress `json:",omitempty"`
 	ShipAddr             *PhysicalAddress `json:",omitempty"`


### PR DESCRIPTION
This alters the behavior of omitempty so it
becomes possible to create tax-exempt customers.