### PR TITLE
Append package version v2 to go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rwestlund/quickbooks-go
+module github.com/rwestlund/quickbooks-go/v2
 
 go 1.20
 


### PR DESCRIPTION
I believe this should resolve the issue mentioned here so that v2 is installable:

https://github.com/rwestlund/quickbooks-go/pull/18#issuecomment-2103624886

It's possible more would be needed for v2 to be fully installable, I haven't tested this