### PR TITLE
update CI to leverage stable and oldstable aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,20 @@
 on: [push, pull_request]
 name: Build
 jobs:
-  build:
-    strategy:
-      matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build
-        run: go build ./...
-      - name: Test
-        run: go test -cover github.com/rwestlund/quickbooks-go
+    build:
+        strategy:
+            matrix:
+                go-version: [stable, oldstable]
+                os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - name: Install Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: ${{ matrix.go-version }}
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Build
+              run: go build ./...
+            - name: Test
+              run: go test -cover .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ jobs:
                 os: [ubuntu-latest, macos-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
             - name: Install Go
               uses: actions/setup-go@v5
               with:
                   go-version: ${{ matrix.go-version }}
-            - name: Checkout code
-              uses: actions/checkout@v4
             - name: Build
               run: go build ./...
             - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 # IntelliJ
 .idea
+.zed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # quickbooks-go
+
 ![Build](https://github.com/rwestlund/quickbooks-go/workflows/Build/badge.svg)
 [![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](http://godoc.org/github.com/rwestlund/quickbooks-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rwestlund/quickbooks-go)](https://goreportcard.com/report/github.com/rwestlund/quickbooks-go)
@@ -16,6 +17,7 @@ use case. Pull requests welcome :)
 Before you can initialize the client, you'll need to obtain an authorization code. You can see an example of this from QuickBooks' [OAuth Playground](https://developer.intuit.com/app/developer/playground).
 
 See [_auth_flow_test.go_](./examples/auth_flow_test.go)
+
 ```go
 clientId     := "<your-client-id>"
 clientSecret := "<your-client-secret>"
@@ -57,6 +59,7 @@ qbClient.RevokeToken(bearerToken.RefreshToken)
 ## Re-using tokens
 
 See [_reuse_token_test.go_](./examples/reuse_token_test.go)
+
 ```go
 clientId     := "<your-client-id>"
 clientSecret := "<your-client-secret>"
@@ -82,4 +85,5 @@ fmt.Println(info)
 ```
 
 # License
+
 BSD-2-Clause

--- a/data/testing/bill.json
+++ b/data/testing/bill.json
@@ -1,60 +1,60 @@
 {
-  "Bill": {
-    "SyncToken": "2",
-    "domain": "QBO",
-    "APAccountRef": {
-      "name": "Accounts Payable (A/P)",
-      "value": "33"
-    },
-    "VendorRef": {
-      "name": "Norton Lumber and Building Materials",
-      "value": "46"
-    },
-    "TxnDate": "2014-11-06",
-    "TotalAmt": 103.55,
-    "CurrencyRef": {
-      "name": "United States Dollar",
-      "value": "USD"
-    },
-    "LinkedTxn": [
-      {
-        "TxnId": "118",
-        "TxnType": "BillPaymentCheck"
-      }
-    ],
-    "SalesTermRef": {
-      "value": "3"
-    },
-    "DueDate": "2014-12-06",
-    "sparse": false,
-    "Line": [
-      {
-        "DetailType": "AccountBasedExpenseLineDetail",
-        "Amount": 103.55,
-        "Id": "1",
-        "AccountBasedExpenseLineDetail": {
-          "TaxCodeRef": {
-            "value": "TAX"
-          },
-          "AccountRef": {
-            "name": "Job Expenses:Job Materials:Decks and Patios",
-            "value": "64"
-          },
-          "BillableStatus": "Billable",
-          "CustomerRef": {
-            "name": "Travis Waldron",
-            "value": "26"
-          }
-        },
-        "Description": "Lumber"
-      }
-    ],
-    "Balance": 0,
-    "Id": "25",
-    "MetaData": {
-      "CreateTime": "2014-11-06T15:37:25-08:00",
-      "LastUpdatedTime": "2015-02-09T10:11:11-08:00"
-    }
-  },
-  "time": "2015-02-09T10:17:20.251-08:00"
+	"Bill": {
+		"SyncToken": "2",
+		"domain": "QBO",
+		"APAccountRef": {
+			"name": "Accounts Payable (A/P)",
+			"value": "33"
+		},
+		"VendorRef": {
+			"name": "Norton Lumber and Building Materials",
+			"value": "46"
+		},
+		"TxnDate": "2014-11-06",
+		"TotalAmt": 103.55,
+		"CurrencyRef": {
+			"name": "United States Dollar",
+			"value": "USD"
+		},
+		"LinkedTxn": [
+			{
+				"TxnId": "118",
+				"TxnType": "BillPaymentCheck"
+			}
+		],
+		"SalesTermRef": {
+			"value": "3"
+		},
+		"DueDate": "2014-12-06",
+		"sparse": false,
+		"Line": [
+			{
+				"DetailType": "AccountBasedExpenseLineDetail",
+				"Amount": 103.55,
+				"Id": "1",
+				"AccountBasedExpenseLineDetail": {
+					"TaxCodeRef": {
+						"value": "TAX"
+					},
+					"AccountRef": {
+						"name": "Job Expenses:Job Materials:Decks and Patios",
+						"value": "64"
+					},
+					"BillableStatus": "Billable",
+					"CustomerRef": {
+						"name": "Travis Waldron",
+						"value": "26"
+					}
+				},
+				"Description": "Lumber"
+			}
+		],
+		"Balance": 0,
+		"Id": "25",
+		"MetaData": {
+			"CreateTime": "2014-11-06T15:37:25-08:00",
+			"LastUpdatedTime": "2015-02-09T10:11:11-08:00"
+		}
+	},
+	"time": "2015-02-09T10:17:20.251-08:00"
 }

--- a/data/testing/vendor.json
+++ b/data/testing/vendor.json
@@ -1,40 +1,40 @@
 {
-  "Vendor": {
-    "PrimaryEmailAddr": {
-      "Address": "Books@Intuit.com"
-    },
-    "Vendor1099": false,
-    "domain": "QBO",
-    "GivenName": "Bessie",
-    "DisplayName": "Books by Bessie",
-    "BillAddr": {
-      "City": "Palo Alto",
-      "Line1": "15 Main St.",
-      "PostalCode": "94303",
-      "Lat": "37.445013",
-      "Long": "-122.1391443",
-      "CountrySubDivisionCode": "CA",
-      "Id": "31"
-    },
-    "SyncToken": "0",
-    "PrintOnCheckName": "Books by Bessie",
-    "FamilyName": "Williams",
-    "PrimaryPhone": {
-      "FreeFormNumber": "(650) 555-7745"
-    },
-    "AcctNum": "1345",
-    "CompanyName": "Books by Bessie",
-    "WebAddr": {
-      "URI": "http://www.booksbybessie.co"
-    },
-    "sparse": false,
-    "Active": true,
-    "Balance": 0,
-    "Id": "30",
-    "MetaData": {
-      "CreateTime": "2014-09-12T10:07:56-07:00",
-      "LastUpdatedTime": "2014-09-17T11:13:46-07:00"
-    }
-  },
-  "time": "2015-07-28T13:33:09.453-07:00"
+	"Vendor": {
+		"PrimaryEmailAddr": {
+			"Address": "Books@Intuit.com"
+		},
+		"Vendor1099": false,
+		"domain": "QBO",
+		"GivenName": "Bessie",
+		"DisplayName": "Books by Bessie",
+		"BillAddr": {
+			"City": "Palo Alto",
+			"Line1": "15 Main St.",
+			"PostalCode": "94303",
+			"Lat": "37.445013",
+			"Long": "-122.1391443",
+			"CountrySubDivisionCode": "CA",
+			"Id": "31"
+		},
+		"SyncToken": "0",
+		"PrintOnCheckName": "Books by Bessie",
+		"FamilyName": "Williams",
+		"PrimaryPhone": {
+			"FreeFormNumber": "(650) 555-7745"
+		},
+		"AcctNum": "1345",
+		"CompanyName": "Books by Bessie",
+		"WebAddr": {
+			"URI": "http://www.booksbybessie.co"
+		},
+		"sparse": false,
+		"Active": true,
+		"Balance": 0,
+		"Id": "30",
+		"MetaData": {
+			"CreateTime": "2014-09-12T10:07:56-07:00",
+			"LastUpdatedTime": "2014-09-17T11:13:46-07:00"
+		}
+	},
+	"time": "2015-07-28T13:33:09.453-07:00"
 }


### PR DESCRIPTION
The current CI has hardcoded go versions in the build matrix. Updating to a newer setup-go action allows the use of `stable` (currently `go 1.23`) and the `oldstable` (currently `go 1.22`) aliases, which will update when `go 1.24` (and subsequent versions) is released.