### PR TITLE
Remove unnecessary logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Test
-        run: go test -cover github.com/rwestlund/quickbooks-go
+        run: go test -cover github.com/nsotgui/quickbooks-go

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 quickbooks-go is a Go library that provides access to Intuit's QuickBooks
 Online API.
 
-**NOTE:** This library is very incomplete. I just implemented the minimum for my
-use case. Pull requests welcome :)
-
 # Example
 
 ## Authorization flow

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # quickbooks-go
-![Build](https://github.com/rwestlund/quickbooks-go/workflows/Build/badge.svg)
-[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](http://godoc.org/github.com/rwestlund/quickbooks-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/rwestlund/quickbooks-go)](https://goreportcard.com/report/github.com/rwestlund/quickbooks-go)
+![Build](https://github.com/nsotgui/quickbooks-go/workflows/Build/badge.svg)
+[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](http://godoc.org/github.com/nsotgui/quickbooks-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nsotgui/quickbooks-go)](https://goreportcard.com/report/github.com/nsotgui/quickbooks-go)
 
 quickbooks-go is a Go library that provides access to Intuit's QuickBooks
 Online API.

--- a/bill.go
+++ b/bill.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 type Bill struct {
@@ -40,10 +41,118 @@ func (c *Client) CreateBill(bill *Bill) (*Bill, error) {
 	}
 	u.Path = "/v3/company/" + c.RealmID + "/bill"
 	var v = url.Values{}
-	v.Add("minorversion", "55")
+	v.Add("minorversion", minorVersion)
 	u.RawQuery = v.Encode()
 	var j []byte
 	j, err = json.Marshal(bill)
+	if err != nil {
+		return nil, err
+	}
+	var req *http.Request
+	req, err = http.NewRequest("POST", u.String(), bytes.NewBuffer(j))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+
+	var r struct {
+		Bill Bill
+		Time Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.Bill, err
+}
+
+// QueryBill gets the bill
+func (c *Client) QueryBill(selectStatement string) ([]Bill, error) {
+	var r struct {
+		QueryResponse struct {
+			Bill          []Bill
+			StartPosition int
+			MaxResults    int
+		}
+	}
+	err := c.query(selectStatement, &r)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.QueryResponse.Bill == nil {
+		r.QueryResponse.Bill = make([]Bill, 0)
+	}
+	return r.QueryResponse.Bill, nil
+}
+
+// GetBills gets the bills
+func (c *Client) GetBills(startpos int, pagesize int) ([]Bill, error) {
+	q := "SELECT * FROM Bill ORDERBY Id STARTPOSITION " +
+		strconv.Itoa(startpos) + " MAXRESULTS " + strconv.Itoa(pagesize)
+	return c.QueryBill(q)
+}
+
+// GetBillByID returns a bill with a given ID.
+func (c *Client) GetBillByID(id string) (*Bill, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/bill/" + id
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var req *http.Request
+	req, err = http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+	var r struct {
+		Bill Bill
+		Time Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.Bill, err
+}
+
+// UpdateBill updates the bill
+func (c *Client) UpdateBill(bill *Bill) (*Bill, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/bill"
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var d = struct {
+		*Bill
+		Sparse bool `json:"sparse"`
+	}{
+		Bill:   bill,
+		Sparse: true,
+	}
+	var j []byte
+	j, err = json.Marshal(d)
 	if err != nil {
 		return nil, err
 	}

--- a/class.go
+++ b/class.go
@@ -8,12 +8,16 @@ import (
 )
 
 type Class struct {
-	ID                 string `json:"Id,omitempty"`
-	Name               string `json:",omitempty"`
-	SyncToken          string `json:",omitempty"`
-	ParentRef          string `json:",omitempty"`
-	SubClass           bool   `json:",omitempty"`
-	FullyQualifiedName string `json:",omitempty"`
+	ID                 string    `json:"Id,omitempty"`
+	Name               string    `json:",omitempty"`
+	SyncToken          string    `json:",omitempty"`
+	ParentRef          ParentRef `json:",omitempty"`
+	SubClass           bool      `json:",omitempty"`
+	FullyQualifiedName string    `json:",omitempty"`
+}
+
+type ParentRef struct {
+	Value string `json:"value"`
 }
 
 // GetClasses fetches classes based on a page size

--- a/class.go
+++ b/class.go
@@ -1,0 +1,77 @@
+package quickbooks
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type Class struct {
+	ID                 string `json:"Id,omitempty"`
+	Name               string `json:",omitempty"`
+	SyncToken          string `json:",omitempty"`
+	ParentRef          string `json:",omitempty"`
+	SubClass           bool   `json:",omitempty"`
+	FullyQualifiedName string `json:",omitempty"`
+}
+
+// GetClasses fetches classes based on a page size
+func (c *Client) GetClasses(startpos int, pagesize int) ([]Class, error) {
+	q := "SELECT * FROM Account ORDERBY Id STARTPOSITION " +
+		strconv.Itoa(startpos) + " MAXRESULTS " + strconv.Itoa(pagesize)
+	return c.QueryClasses(q)
+}
+
+// QueryClasses runs a select statement for classes
+func (c *Client) QueryClasses(selectStatement string) ([]Class, error) {
+	var r struct {
+		QueryResponse struct {
+			Class         []Class
+			StartPosition int `json:"startPosition"`
+			MaxResults    int `json:"totalCount"`
+		}
+	}
+	err := c.query(selectStatement, &r)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.QueryResponse.Class == nil {
+		r.QueryResponse.Class = make([]Class, 0)
+	}
+	return r.QueryResponse.Class, nil
+}
+
+// GetClassByID returns an account with a given ID.
+func (c *Client) GetClassByID(id string) (*Class, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/class/" + id
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var req *http.Request
+	req, err = http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+	var r struct {
+		Class Class
+		Time  Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.Class, err
+}

--- a/class.go
+++ b/class.go
@@ -18,7 +18,7 @@ type Class struct {
 
 // GetClasses fetches classes based on a page size
 func (c *Client) GetClasses(startpos int, pagesize int) ([]Class, error) {
-	q := "SELECT * FROM Account ORDERBY Id STARTPOSITION " +
+	q := "SELECT * FROM Class ORDERBY Id STARTPOSITION " +
 		strconv.Itoa(startpos) + " MAXRESULTS " + strconv.Itoa(pagesize)
 	return c.QueryClasses(q)
 }

--- a/client.go
+++ b/client.go
@@ -7,18 +7,18 @@ Package quickbooks provides access to Intuit's QuickBooks Online API.
 NOTE: This library is very incomplete. I just implemented the minimum for my
 use case. Pull requests welcome :)
 
- // Do this after you go through the normal OAuth process.
- var client = oauth2.NewClient(ctx, tokenSource)
+	 // Do this after you go through the normal OAuth process.
+	 var client = oauth2.NewClient(ctx, tokenSource)
 
- // Initialize the client handle.
- var qb = quickbooks.Client{
-	 Client: client,
-	 Endpoint: quickbooks.SandboxEndpoint,
-	 RealmID: "some company account ID"'
- }
+	 // Initialize the client handle.
+	 var qb = quickbooks.Client{
+		 Client: client,
+		 Endpoint: quickbooks.SandboxEndpoint,
+		 RealmID: "some company account ID"'
+	 }
 
- // Make a request!
- var companyInfo, err = qb.FetchCompanyInfo()
+	 // Make a request!
+	 var companyInfo, err = qb.FetchCompanyInfo()
 */
 package quickbooks
 

--- a/client.go
+++ b/client.go
@@ -33,6 +33,30 @@ const (
 	AccountingScope = "com.intuit.quickbooks.accounting"
 )
 
+// Types of options available per request to the client.
+type ClientOptType string
+
+// Types of options supported by this SDK
+var ClientOptTypeQueryParameter = ClientOptType("query_parameter")
+
+// Options available on requests made by the client.  Usually passed along as query parameters
+type ClientOpt struct {
+	// The type of the option.
+	Type ClientOptType
+	// The API name of the option
+	Name string
+	// The value of the option
+	Value string
+}
+
+// Available Options supported by this sdk
+
+var ClientOptAllowDuplicateDocNum = ClientOpt{
+	Type:  ClientOptTypeQueryParameter,
+	Name:  "include",
+	Value: "allowduplicatedocnum",
+}
+
 // Client is your handle to the QuickBooks API.
 type Client struct {
 	// Get this from oauth2.NewClient().

--- a/client.go
+++ b/client.go
@@ -24,8 +24,13 @@ package quickbooks
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/url"
+)
+
+const (
+	AccountingScope = "com.intuit.quickbooks.accounting"
 )
 
 // Client is your handle to the QuickBooks API.
@@ -60,6 +65,28 @@ func NewQuickbooksClient(clientId string, clientSecret string, realmID string, i
 		client.Client = getHttpClient(token)
 	}
 	return &client, nil
+}
+
+// GetAuthorizationUrl Get the authorization Url
+func (c *Client) GetAuthorizationUrl(scope string, csrf string, redirectUri string) string {
+	var Url *url.URL
+
+	authorizationEndpoint := c.discoveryAPI.AuthorizationEndpoint
+	Url, err := url.Parse(authorizationEndpoint)
+	if err != nil {
+		log.Println("error parsing url")
+	}
+
+	parameters := url.Values{}
+	parameters.Add("client_id", c.clientId)
+	parameters.Add("response_type", "code")
+	parameters.Add("scope", scope)
+	parameters.Add("redirect_uri", redirectUri)
+	parameters.Add("state", csrf)
+	Url.RawQuery = parameters.Encode()
+
+	log.Printf("Encoded URL is %q\n", Url.String())
+	return Url.String()
 }
 
 // FetchCompanyInfo returns the QuickBooks CompanyInfo object. This is a good

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,31 @@
+package quickbooks
+
+import (
+	"errors"
+	"os"
+)
+
+// Client used for testing only
+func getClient() (*Client, error) {
+	clientId := os.Getenv("CLIENT_ID")
+	if clientId == "" {
+		return nil, errors.New("CLIENT_ID not defined")
+	}
+	clientSecret := os.Getenv("CLIENT_SECRET")
+	if clientSecret == "" {
+		return nil, errors.New("CLIENT_SECRET not defined")
+	}
+	realmID := os.Getenv("REALM_ID")
+	if realmID == "" {
+		return nil, errors.New("REALM_ID not defined")
+	}
+	accessToken := os.Getenv("ACCESS_TOKEN")
+	if accessToken == "" {
+		return nil, errors.New("ACCESS_TOKEN not defined")
+	}
+	token := BearerToken{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+	}
+	return NewQuickbooksClient(clientId, clientSecret, realmID, false, &token)
+}

--- a/data/testing/journal-entry.json
+++ b/data/testing/journal-entry.json
@@ -1,0 +1,44 @@
+{
+	"time": "2015-06-29T12:43:42.132-07:00",
+	"JournalEntry": {
+		"SyncToken": "0",
+		"domain": "QBO",
+		"TxnDate": "2015-06-29",
+		"sparse": false,
+		"Line": [
+			{
+				"JournalEntryLineDetail": {
+					"PostingType": "Debit",
+					"AccountRef": {
+						"name": "Job Expenses:Job Materials:Fountain and Garden Lighting",
+						"value": "65"
+					}
+				},
+				"DetailType": "JournalEntryLineDetail",
+				"Amount": 25.54,
+				"Id": "0",
+				"Description": "Four sprinkler heads damaged"
+			},
+			{
+				"JournalEntryLineDetail": {
+					"PostingType": "Credit",
+					"AccountRef": {
+						"name": "Notes Payable",
+						"value": "44"
+					}
+				},
+				"DetailType": "JournalEntryLineDetail",
+				"Amount": 25.54,
+				"Id": "1",
+				"Description": "Sprinkler Hds - Sprinkler Hds Inventory Adjustment"
+			}
+		],
+		"Adjustment": false,
+		"Id": "227",
+		"TxnTaxDetail": {},
+		"MetaData": {
+			"CreateTime": "2015-06-29T12:33:57-07:00",
+			"LastUpdatedTime": "2015-06-29T12:33:57-07:00"
+		}
+	}
+}

--- a/data/testing/purchase.json
+++ b/data/testing/purchase.json
@@ -1,0 +1,54 @@
+{
+	"Purchase": {
+		"SyncToken": "0",
+		"domain": "QBO",
+		"PurchaseEx": {
+			"any": [
+				{
+					"name": "{http://schema.intuit.com/finance/v3}NameValue",
+					"nil": false,
+					"value": {
+						"Name": "TxnType",
+						"Value": "54"
+					},
+					"declaredType": "com.intuit.schema.finance.v3.NameValue",
+					"scope": "javax.xml.bind.JAXBElement$GlobalScope",
+					"globalScope": true,
+					"typeSubstituted": false
+				}
+			]
+		},
+		"TxnDate": "2015-07-27",
+		"TotalAmt": 10.0,
+		"PaymentType": "Cash",
+		"sparse": false,
+		"Line": [
+			{
+				"DetailType": "AccountBasedExpenseLineDetail",
+				"Amount": 10.0,
+				"Id": "1",
+				"AccountBasedExpenseLineDetail": {
+					"TaxCodeRef": {
+						"value": "NON"
+					},
+					"AccountRef": {
+						"name": "Meals and Entertainment",
+						"value": "13"
+					},
+					"BillableStatus": "NotBillable"
+				}
+			}
+		],
+		"AccountRef": {
+			"name": "Checking",
+			"value": "35"
+		},
+		"CustomField": [],
+		"Id": "252",
+		"MetaData": {
+			"CreateTime": "2015-07-27T10:37:26-07:00",
+			"LastUpdatedTime": "2015-07-27T10:37:26-07:00"
+		}
+	},
+	"time": "2015-07-27T10:39:33.171-07:00"
+}

--- a/defs.go
+++ b/defs.go
@@ -19,4 +19,4 @@ const (
 
 const queryPageSize = 1000
 
-const minorVersion = "52"
+const minorVersion = "65"

--- a/discovery.go
+++ b/discovery.go
@@ -9,7 +9,6 @@ import (
 
 // Call the discovery API.
 // See https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/openid-connect#discovery-document
-//
 func CallDiscoveryAPI(discoveryEndpoint EndpointURL) *DiscoveryAPI {
 	log.Println("Entering CallDiscoveryAPI ")
 	client := &http.Client{}

--- a/discovery.go
+++ b/discovery.go
@@ -21,6 +21,9 @@ func CallDiscoveryAPI(discoveryEndpoint EndpointURL) *DiscoveryAPI {
 	request.Header.Set("accept", "application/json")
 
 	resp, err := client.Do(request)
+	if err != nil {
+		log.Fatalln(err)
+	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 )
 
 // Error implements the error interface.
@@ -22,16 +21,17 @@ func (f Failure) Error() string {
 
 // Failure is the outermost struct that holds an error response.
 type Failure struct {
-	Fault struct {
-		Error []struct {
-			Message string
-			Detail  string
-			Code    string `json:"code"`
-			Element string `json:"element"`
-		}
-		Type string `json:"type"`
+	Fault Fault `json:"fault"`
+}
+
+type Fault struct {
+	Error []struct {
+		Message string
+		Detail  string
+		Code    string `json:"code"`
+		Element string `json:"element"`
 	}
-	Time Date `json:"time"`
+	Type string `json:"type"`
 }
 
 // parseFailure takes a response reader and tries to parse a Failure.
@@ -43,8 +43,7 @@ func parseFailure(res *http.Response) error {
 	var errStruct Failure
 	err = json.Unmarshal(msg, &errStruct)
 	if err != nil {
-		return errors.New(strconv.Itoa(res.StatusCode) +
-			" " + string(msg))
+		return err
 	}
 	return errStruct
 }

--- a/examples/auth_flow_test.go
+++ b/examples/auth_flow_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/neonmoose/quickbooks-go"
+	"github.com/justworkshr/quickbooks-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples/auth_flow_test.go
+++ b/examples/auth_flow_test.go
@@ -2,9 +2,10 @@ package examples
 
 import (
 	"fmt"
-	"github.com/nsotgui/quickbooks-go"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/rwestlund/quickbooks-go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuthorizationFlow(t *testing.T) {

--- a/examples/auth_flow_test.go
+++ b/examples/auth_flow_test.go
@@ -2,7 +2,7 @@ package examples
 
 import (
 	"fmt"
-	"github.com/rwestlund/quickbooks-go"
+	"github.com/nsotgui/quickbooks-go"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/examples/auth_flow_test.go
+++ b/examples/auth_flow_test.go
@@ -15,6 +15,9 @@ func TestAuthorizationFlow(t *testing.T) {
 	qbClient, err := quickbooks.NewQuickbooksClient(clientId, clientSecret, realmId, false, nil)
 	require.NoError(t, err)
 
+	// Get the authorization url
+	qbClient.GetAuthorizationUrl(quickbooks.AccountingScope, "random-string", "https://localhost/redirect_uri")
+
 	// To do first when you receive the authorization code from quickbooks callback
 	authorizationCode := "<received-from-callback>"
 	bearerToken, err := qbClient.RetrieveBearerToken(authorizationCode)

--- a/examples/auth_flow_test.go
+++ b/examples/auth_flow_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/rwestlund/quickbooks-go"
+	"github.com/neonmoose/quickbooks-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples/reuse_token_test.go
+++ b/examples/reuse_token_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/neonmoose/quickbooks-go"
+	"github.com/justworkshr/quickbooks-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples/reuse_token_test.go
+++ b/examples/reuse_token_test.go
@@ -2,7 +2,7 @@ package examples
 
 import (
 	"fmt"
-	"github.com/rwestlund/quickbooks-go"
+	"github.com/nsotgui/quickbooks-go"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/examples/reuse_token_test.go
+++ b/examples/reuse_token_test.go
@@ -2,9 +2,10 @@ package examples
 
 import (
 	"fmt"
-	"github.com/nsotgui/quickbooks-go"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/rwestlund/quickbooks-go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReuseToken(t *testing.T) {

--- a/examples/reuse_token_test.go
+++ b/examples/reuse_token_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/rwestlund/quickbooks-go"
+	"github.com/neonmoose/quickbooks-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/neonmoose/quickbooks-go
+module github.com/justworkshr/quickbooks-go
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rwestlund/quickbooks-go
+module github.com/neonmoose/quickbooks-go
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,5 @@
-module github.com/nsotgui/quickbooks-go
+module github.com/rwestlund/quickbooks-go
+
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,19 @@
 module github.com/rwestlund/quickbooks-go
 
-
-go 1.14
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
 	gopkg.in/guregu/null.v4 v4.0.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rwestlund/quickbooks-go
+module github.com/nsotgui/quickbooks-go
 
 go 1.14
 

--- a/go.sum
+++ b/go.sum
@@ -352,7 +352,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/invoice.go
+++ b/invoice.go
@@ -62,6 +62,27 @@ type TxnTaxDetail struct {
 	TaxLine       []Line        `json:",omitempty"`
 }
 
+const (
+	PostingTypeCredit         = "Credit"
+	PostingTypeDebit          = "Debit"
+	BillableStatusBillable    = "Billable"
+	BillableStatusNotBillable = "NotBillable"
+	BillableStatus            = "HasBeenBilled"
+)
+
+type JournalEntryLineDetail struct {
+	JournalCodeRef  ReferenceType `json:",omitempty"`
+	PostingType     string        `json:",omitempty"`
+	AccountRef      ReferenceType `json:",omitempty"`
+	TaxApplicableOn string        `json:",omitempty"`
+	TaxInclusiveAmt json.Number   `json:",omitempty"`
+	ClassRef        ReferenceType `json:",omitempty"`
+	DepartmentRef   ReferenceType `json:",omitempty"`
+	TaxCodeRef      ReferenceType `json:",omitempty"`
+	BillableStatus  string        `json:",omitempty"`
+	Entity          ReferenceType `json:",omitempty"`
+}
+
 // AccountBasedExpenseLineDetail
 type AccountBasedExpenseLineDetail struct {
 	AccountRef ReferenceType
@@ -81,10 +102,11 @@ type Line struct {
 	Description                   string `json:",omitempty"`
 	Amount                        json.Number
 	DetailType                    string
-	AccountBasedExpenseLineDetail AccountBasedExpenseLineDetail
-	SalesItemLineDetail           SalesItemLineDetail `json:",omitempty"`
-	DiscountLineDetail            DiscountLineDetail  `json:",omitempty"`
-	TaxLineDetail                 TaxLineDetail       `json:",omitempty"`
+	AccountBasedExpenseLineDetail AccountBasedExpenseLineDetail `json:",omitempty"`
+	JournalEntryLineDetail        JournalEntryLineDetail        `json:",omitempty"`
+	SalesItemLineDetail           SalesItemLineDetail           `json:",omitempty"`
+	DiscountLineDetail            DiscountLineDetail            `json:",omitempty"`
+	TaxLineDetail                 TaxLineDetail                 `json:",omitempty"`
 }
 
 // TaxLineDetail ...

--- a/invoice.go
+++ b/invoice.go
@@ -62,6 +62,11 @@ type TxnTaxDetail struct {
 	TaxLine       []Line        `json:",omitempty"`
 }
 
+type Entity struct {
+	Type      string        `json:",omitempty"`
+	EntityRef ReferenceType `json:",omitempty"`
+}
+
 const (
 	PostingTypeCredit         = "Credit"
 	PostingTypeDebit          = "Debit"
@@ -80,7 +85,7 @@ type JournalEntryLineDetail struct {
 	DepartmentRef   ReferenceType `json:",omitempty"`
 	TaxCodeRef      ReferenceType `json:",omitempty"`
 	BillableStatus  string        `json:",omitempty"`
-	Entity          ReferenceType `json:",omitempty"`
+	Entity          Entity        `json:",omitempty"`
 }
 
 // AccountBasedExpenseLineDetail

--- a/journal_entry.go
+++ b/journal_entry.go
@@ -1,0 +1,177 @@
+package quickbooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type JournalEntry struct {
+	ID                      string         `json:"Id,omitempty"`
+	Line                    []Line         `json:",omitempty"`
+	SyncToken               string         `json:",omitempty"`
+	CurrencyRef             ReferenceType  `json:",omitempty"`
+	DocNumber               string         `json:",omitempty"`
+	PrivateNote             string         `json:",omitempty"`
+	TxnDate                 Date           `json:",omitempty"`
+	ExchangeRate            json.Number    `json:",omitempty"`
+	TaxRateRef              *ReferenceType `json:",omitempty"`
+	TransactionLocationType string         `json:",omitempty"`
+	TxnTaxDetail            TxnTaxDetail   `json:",omitempty"`
+	//GlobalTaxCalculation
+	Adjustment   bool          `json:",omitempty"`
+	MetaData     MetaData      `json:",omitempty"`
+	RecurDataRef ReferenceType `json:",omitempty"`
+	TotalAmt     json.Number   `json:",omitempty"`
+}
+
+// CreateJournalEntry creates the journalEntry
+func (c *Client) CreateJournalEntry(journalEntry *JournalEntry) (*JournalEntry, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/journalentry"
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var j []byte
+	j, err = json.Marshal(journalEntry)
+	if err != nil {
+		return nil, err
+	}
+	var req *http.Request
+	req, err = http.NewRequest("POST", u.String(), bytes.NewBuffer(j))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+
+	var r struct {
+		JournalEntry JournalEntry
+		Time         Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.JournalEntry, err
+}
+
+// QueryJournalEntry gets the journalEntry
+func (c *Client) QueryJournalEntry(selectStatement string) ([]JournalEntry, error) {
+	var r struct {
+		QueryResponse struct {
+			JournalEntry  []JournalEntry
+			StartPosition int
+			MaxResults    int
+		}
+	}
+	err := c.query(selectStatement, &r)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.QueryResponse.JournalEntry == nil {
+		r.QueryResponse.JournalEntry = make([]JournalEntry, 0)
+	}
+	return r.QueryResponse.JournalEntry, nil
+}
+
+// GetJournalEntrys gets the journalEntry
+func (c *Client) GetJournalEntrys(startpos int, pagesize int) ([]JournalEntry, error) {
+	q := "SELECT * FROM JournalEntry ORDERBY Id STARTPOSITION " +
+		strconv.Itoa(startpos) + " MAXRESULTS " + strconv.Itoa(pagesize)
+	return c.QueryJournalEntry(q)
+}
+
+// GetJournalEntryByID returns an journalEntry with a given ID.
+func (c *Client) GetJournalEntryByID(id string) (*JournalEntry, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/journalentry/" + id
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var req *http.Request
+	req, err = http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+	var r struct {
+		JournalEntry JournalEntry
+		Time         Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.JournalEntry, err
+}
+
+// UpdateJournalEntry updates the journalEntry
+func (c *Client) UpdateJournalEntry(journalEntry *JournalEntry) (*JournalEntry, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/journalentry"
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var d = struct {
+		*JournalEntry
+		Sparse bool `json:"sparse"`
+	}{
+		JournalEntry: journalEntry,
+		Sparse:       true,
+	}
+	var j []byte
+	j, err = json.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	var req *http.Request
+	req, err = http.NewRequest("POST", u.String(), bytes.NewBuffer(j))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+
+	var r struct {
+		JournalEntry JournalEntry
+		Time         Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.JournalEntry, err
+}

--- a/journal_entry.go
+++ b/journal_entry.go
@@ -28,7 +28,7 @@ type JournalEntry struct {
 }
 
 // CreateJournalEntry creates the journalEntry
-func (c *Client) CreateJournalEntry(journalEntry *JournalEntry) (*JournalEntry, error) {
+func (c *Client) CreateJournalEntry(journalEntry *JournalEntry, opts ...ClientOpt) (*JournalEntry, error) {
 	var u, err = url.Parse(string(c.Endpoint))
 	if err != nil {
 		return nil, err
@@ -36,6 +36,13 @@ func (c *Client) CreateJournalEntry(journalEntry *JournalEntry) (*JournalEntry, 
 	u.Path = "/v3/company/" + c.RealmID + "/journalentry"
 	var v = url.Values{}
 	v.Add("minorversion", minorVersion)
+
+	for _, o := range opts {
+		if o.Type == ClientOptTypeQueryParameter {
+			v.Add(o.Name, o.Value)
+		}
+	}
+
 	u.RawQuery = v.Encode()
 	var j []byte
 	j, err = json.Marshal(journalEntry)
@@ -129,7 +136,7 @@ func (c *Client) GetJournalEntryByID(id string) (*JournalEntry, error) {
 }
 
 // UpdateJournalEntry updates the journalEntry
-func (c *Client) UpdateJournalEntry(journalEntry *JournalEntry) (*JournalEntry, error) {
+func (c *Client) UpdateJournalEntry(journalEntry *JournalEntry, opts ...ClientOpt) (*JournalEntry, error) {
 	var u, err = url.Parse(string(c.Endpoint))
 	if err != nil {
 		return nil, err
@@ -137,6 +144,13 @@ func (c *Client) UpdateJournalEntry(journalEntry *JournalEntry) (*JournalEntry, 
 	u.Path = "/v3/company/" + c.RealmID + "/journalentry"
 	var v = url.Values{}
 	v.Add("minorversion", minorVersion)
+
+	for _, o := range opts {
+		if o.Type == ClientOptTypeQueryParameter {
+			v.Add(o.Name, o.Value)
+		}
+	}
+
 	u.RawQuery = v.Encode()
 	var d = struct {
 		*JournalEntry

--- a/journal_entry_test.go
+++ b/journal_entry_test.go
@@ -31,7 +31,7 @@ func TestJournalEntryJSON(t *testing.T) {
 		log.Fatal("When decoding JSON file: ", err)
 	}
 	assert.Equal(t, "0", r.JournalEntry.SyncToken)
-	assert.Equal(t, "2015-07-27T00:00:00+00:00", r.JournalEntry.TxnDate.String())
+	assert.Equal(t, "2015-06-29T00:00:00+00:00", r.JournalEntry.TxnDate.String())
 	assert.False(t, r.JournalEntry.Adjustment)
 	assert.Equal(t, "227", r.JournalEntry.ID)
 	assert.Equal(t, "2015-06-29T12:33:57-07:00", r.JournalEntry.MetaData.CreateTime.String())

--- a/journal_entry_test.go
+++ b/journal_entry_test.go
@@ -1,0 +1,81 @@
+package quickbooks
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestJournalEntryJSON(t *testing.T) {
+	jsonFile, err := os.Open("data/testing/journal-entry.json")
+	if err != nil {
+		log.Fatal("When opening JSON file: ", err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		log.Fatal("When reading JSON file: ", err)
+	}
+
+	var r struct {
+		JournalEntry JournalEntry
+		Time         Date
+	}
+	err = json.Unmarshal(byteValue, &r)
+	if err != nil {
+		log.Fatal("When decoding JSON file: ", err)
+	}
+	assert.Equal(t, "0", r.JournalEntry.SyncToken)
+	assert.Equal(t, "2015-07-27T00:00:00+00:00", r.JournalEntry.TxnDate.String())
+	assert.False(t, r.JournalEntry.Adjustment)
+	assert.Equal(t, "227", r.JournalEntry.ID)
+	assert.Equal(t, "2015-06-29T12:33:57-07:00", r.JournalEntry.MetaData.CreateTime.String())
+	assert.Equal(t, "2015-06-29T12:33:57-07:00", r.JournalEntry.MetaData.LastUpdatedTime.String())
+}
+
+func TestJournalEntry(t *testing.T) {
+	qbClient, err := getClient()
+	if err != nil {
+		log.Println(err)
+		t.Skip("Cannot instantiate the client")
+	}
+
+	jsonFile, err := os.Open("data/testing/journal-entry.json")
+	if err != nil {
+		t.Fatal("When opening JSON file: ", err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatal("When reading JSON file: ", err)
+	}
+
+	var r struct {
+		JournalEntry JournalEntry
+		Time         Date
+	}
+	err = json.Unmarshal(byteValue, &r)
+	if err != nil {
+		t.Fatal("When decoding JSON file: ", err)
+	}
+
+	r.JournalEntry.ID = ""
+	r.JournalEntry.TxnDate.Time = time.Now()
+	createdJournalEntry, err := qbClient.CreateJournalEntry(&r.JournalEntry)
+	assert.NoError(t, err)
+
+	newJournalEntry, err := qbClient.GetJournalEntryByID(createdJournalEntry.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, createdJournalEntry.ID, newJournalEntry.ID)
+
+	createdJournalEntry.DocNumber = "NewNumber"
+	newJournalEntry, err = qbClient.UpdateJournalEntry(createdJournalEntry)
+	assert.NoError(t, err)
+	assert.Equal(t, "NewNumber", newJournalEntry.DocNumber)
+}

--- a/purchase.go
+++ b/purchase.go
@@ -1,0 +1,192 @@
+package quickbooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const (
+	PaymentTypeCash       = "Cash"
+	PaymentTypeCheck      = "Check"
+	PaymentTypeCreditCard = "CreditCard"
+)
+
+type Purchase struct {
+	ID          string `json:"Id,omitempty"`
+	Line        []Line
+	PaymentType string           `json:",omitempty"`
+	AccountRef  ReferenceType    `json:",omitempty"`
+	SyncToken   string           `json:",omitempty"`
+	CurrencyRef ReferenceType    `json:",omitempty"`
+	TxnDate     Date             `json:",omitempty"`
+	PrintStatus string           `json:",omitempty"`
+	RemitToAddr *PhysicalAddress `json:",omitempty"`
+	TxnSource   string           `json:",omitempty"`
+	//LinkedTxn
+	//GlobalTaxCalculation
+	TransactionLocationType string        `json:",omitempty"`
+	MetaData                MetaData      `json:",omitempty"`
+	DocNumber               string        `json:",omitempty"`
+	PrivateNote             string        `json:",omitempty"`
+	Credit                  bool          `json:",omitempty"`
+	TxnTaxDetail            TxnTaxDetail  `json:",omitempty"`
+	PaymentMethodRef        ReferenceType `json:",omitempty"`
+	ExchangeRate            json.Number   `json:",omitempty"`
+	DepartmentRef           ReferenceType `json:",omitempty"`
+	EntityRef               ReferenceType `json:",omitempty"`
+	IncludeInAnnualTPAR     bool          `json:",omitempty"`
+	TotalAmt                json.Number   `json:",omitempty"`
+	RecurDataRef            ReferenceType `json:",omitempty"`
+}
+
+// CreatePurchase creates the purchase
+func (c *Client) CreatePurchase(purchase *Purchase) (*Purchase, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/purchase"
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var j []byte
+	j, err = json.Marshal(purchase)
+	if err != nil {
+		return nil, err
+	}
+	var req *http.Request
+	req, err = http.NewRequest("POST", u.String(), bytes.NewBuffer(j))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+
+	var r struct {
+		Purchase Purchase
+		Time     Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.Purchase, err
+}
+
+// QueryPurchase gets the purchase
+func (c *Client) QueryPurchase(selectStatement string) ([]Purchase, error) {
+	var r struct {
+		QueryResponse struct {
+			Purchase      []Purchase
+			StartPosition int
+			MaxResults    int
+		}
+	}
+	err := c.query(selectStatement, &r)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.QueryResponse.Purchase == nil {
+		r.QueryResponse.Purchase = make([]Purchase, 0)
+	}
+	return r.QueryResponse.Purchase, nil
+}
+
+// GetPurchases gets the purchase
+func (c *Client) GetPurchases(startpos int, pagesize int) ([]Purchase, error) {
+	q := "SELECT * FROM Purchase ORDERBY Id STARTPOSITION " +
+		strconv.Itoa(startpos) + " MAXRESULTS " + strconv.Itoa(pagesize)
+	return c.QueryPurchase(q)
+}
+
+// GetPurchaseByID returns an purchase with a given ID.
+func (c *Client) GetPurchaseByID(id string) (*Purchase, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/purchase/" + id
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var req *http.Request
+	req, err = http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+	var r struct {
+		Purchase Purchase
+		Time     Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.Purchase, err
+}
+
+// UpdatePurchase updates the purchase
+func (c *Client) UpdatePurchase(purchase *Purchase) (*Purchase, error) {
+	var u, err = url.Parse(string(c.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/v3/company/" + c.RealmID + "/purchase"
+	var v = url.Values{}
+	v.Add("minorversion", minorVersion)
+	u.RawQuery = v.Encode()
+	var d = struct {
+		*Purchase
+		Sparse bool `json:"sparse"`
+	}{
+		Purchase: purchase,
+		Sparse:   true,
+	}
+	var j []byte
+	j, err = json.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	var req *http.Request
+	req, err = http.NewRequest("POST", u.String(), bytes.NewBuffer(j))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	var res *http.Response
+	res, err = c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, parseFailure(res)
+	}
+
+	var r struct {
+		Purchase Purchase
+		Time     Date
+	}
+	err = json.NewDecoder(res.Body).Decode(&r)
+	return &r.Purchase, err
+}

--- a/purchase_test.go
+++ b/purchase_test.go
@@ -1,0 +1,85 @@
+package quickbooks
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestPurchaseJSON(t *testing.T) {
+	jsonFile, err := os.Open("data/testing/purchase.json")
+	if err != nil {
+		log.Fatal("When opening JSON file: ", err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		log.Fatal("When reading JSON file: ", err)
+	}
+
+	var r struct {
+		Purchase Purchase
+		Time     Date
+	}
+	err = json.Unmarshal(byteValue, &r)
+	if err != nil {
+		log.Fatal("When decoding JSON file: ", err)
+	}
+	assert.Equal(t, "0", r.Purchase.SyncToken)
+	assert.Equal(t, "2015-07-27T00:00:00+00:00", r.Purchase.TxnDate.String())
+	totalAmt, _ := r.Purchase.TotalAmt.Float64()
+	assert.Equal(t, 10.0, totalAmt)
+	assert.Equal(t, "Cash", r.Purchase.PaymentType)
+	assert.Equal(t, "Checking", r.Purchase.AccountRef.Name)
+	assert.Equal(t, "35", r.Purchase.AccountRef.Value)
+	assert.Equal(t, "252", r.Purchase.ID)
+	assert.Equal(t, "2015-07-27T10:37:26-07:00", r.Purchase.MetaData.CreateTime.String())
+	assert.Equal(t, "2015-07-27T10:37:26-07:00", r.Purchase.MetaData.LastUpdatedTime.String())
+}
+
+func TestPurchase(t *testing.T) {
+	qbClient, err := getClient()
+	if err != nil {
+		log.Println(err)
+		t.Skip("Cannot instantiate the client")
+	}
+
+	jsonFile, err := os.Open("data/testing/purchase.json")
+	if err != nil {
+		t.Fatal("When opening JSON file: ", err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatal("When reading JSON file: ", err)
+	}
+
+	var r struct {
+		Purchase Purchase
+		Time     Date
+	}
+	err = json.Unmarshal(byteValue, &r)
+	if err != nil {
+		t.Fatal("When decoding JSON file: ", err)
+	}
+
+	r.Purchase.ID = ""
+	r.Purchase.TxnDate.Time = time.Now()
+	createdPurchase, err := qbClient.CreatePurchase(&r.Purchase)
+	assert.NoError(t, err)
+
+	newPurchase, err := qbClient.GetPurchaseByID(createdPurchase.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, createdPurchase.ID, newPurchase.ID)
+
+	createdPurchase.DocNumber = "NewNumber"
+	newPurchase, err = qbClient.UpdatePurchase(createdPurchase)
+	assert.NoError(t, err)
+	assert.Equal(t, "NewNumber", newPurchase.DocNumber)
+}

--- a/token.go
+++ b/token.go
@@ -22,10 +22,8 @@ type BearerToken struct {
 	XRefreshTokenExpiresIn int64  `json:"x_refresh_token_expires_in"`
 }
 
-//
 // Method to retrieve access token (bearer token)
 // This method can only be called once
-//
 func (c *Client) RetrieveBearerToken(authorizationCode string, redirectURI string) (*BearerToken, error) {
 	client := &http.Client{}
 	data := url.Values{}
@@ -62,9 +60,7 @@ func (c *Client) RetrieveBearerToken(authorizationCode string, redirectURI strin
 	return bearerTokenResponse, err
 }
 
-//
 // Call the refresh endpoint to generate new tokens
-//
 func (c *Client) RefreshToken(refreshToken string) (*BearerToken, error) {
 	client := &http.Client{}
 	data := url.Values{}
@@ -102,9 +98,7 @@ func (c *Client) RefreshToken(refreshToken string) (*BearerToken, error) {
 	return bearerTokenResponse, err
 }
 
-//
 // Call the revoke endpoint to revoke tokens
-//
 func (c *Client) RevokeToken(refreshToken string) error {
 	client := &http.Client{}
 	data := url.Values{}

--- a/token.go
+++ b/token.go
@@ -44,6 +44,10 @@ func (c *Client) RetrieveBearerToken(authorizationCode string, redirectURI strin
 	request.Header.Set("Authorization", "Basic "+basicAuth(c))
 
 	resp, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -79,6 +83,10 @@ func (c *Client) RefreshToken(refreshToken string) (*BearerToken, error) {
 	request.Header.Set("Authorization", "Basic "+basicAuth(c))
 
 	resp, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -115,7 +123,11 @@ func (c *Client) RevokeToken(refreshToken string) error {
 	request.Header.Set("Authorization", "Basic "+basicAuth(c))
 
 	resp, err := client.Do(request)
+	if err != nil {
+		return err
+	}
 	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/token.go
+++ b/token.go
@@ -25,14 +25,14 @@ type BearerToken struct {
 // Method to retrieve access token (bearer token)
 // This method can only be called once
 //
-func (c *Client) RetrieveBearerToken(authorizationCode string) (*BearerToken, error) {
+func (c *Client) RetrieveBearerToken(authorizationCode string, redirectURI string) (*BearerToken, error) {
 	log.Println("Entering RetrieveBearerToken ")
 	client := &http.Client{}
 	data := url.Values{}
 	//set parameters
 	data.Set("grant_type", "authorization_code")
 	data.Add("code", authorizationCode)
-	data.Add("redirect_uri", "https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl")
+	data.Add("redirect_uri", redirectURI)
 
 	request, err := http.NewRequest("POST", string(c.discoveryAPI.TokenEndpoint), bytes.NewBufferString(data.Encode()))
 	if err != nil {

--- a/vendor.go
+++ b/vendor.go
@@ -46,27 +46,37 @@ type Vendor struct {
 	Balance             json.Number      `json:",omitempty"`
 }
 
+type VendorQueryResponse struct {
+	Vendor        []Vendor
+	StartPosition int
+	MaxResults    int
+}
+
+// QueryVendor gets the vendor
+func (c *Client) QueryVendor(selectStatement string) (VendorQueryResponse, error) {
+	var r struct {
+		QueryResponse VendorQueryResponse
+	}
+	err := c.query(selectStatement, &r)
+	if err != nil {
+		return VendorQueryResponse{}, err
+	}
+	return r.QueryResponse, nil
+}
+
 // GetVendors gets the vendors
 func (c *Client) GetVendors(startpos int) ([]Vendor, error) {
-
-	var r struct {
-		QueryResponse struct {
-			Vendor        []Vendor
-			StartPosition int
-			MaxResults    int
-		}
-	}
 	q := "SELECT * FROM Vendor ORDERBY Id STARTPOSITION " +
 		strconv.Itoa(startpos) + " MAXRESULTS " + strconv.Itoa(queryPageSize)
-	err := c.query(q, &r)
+	resp, err := c.QueryVendor(q)
 	if err != nil {
 		return nil, err
 	}
 
-	if r.QueryResponse.Vendor == nil {
-		r.QueryResponse.Vendor = make([]Vendor, 0)
+	if resp.Vendor == nil {
+		resp.Vendor = make([]Vendor, 0)
 	}
-	return r.QueryResponse.Vendor, nil
+	return resp.Vendor, nil
 }
 
 // CreateVendor creates the vendor


### PR DESCRIPTION
### Context
This log statement `Entering CallDiscoveryAPI` is crowding the Ledger service [Datadog dashboard. ](https://app.datadoghq.com/logs?query=service%3Aledger%20-status%3Ainfo&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZfLwFxN3B26rAAAABhBWmZMd0dtWkFBQmxnd2FUQmw5RzN3QS0AAAAkMDE5N2NiYzAtNzEwOS00ZDU3LTk5OWItY2FkMDIyMTRlOGE0AABV1Q&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1750175311356&to_ts=1751471311356&live=true). Not sure if this is providing much value for us, and it falsely logs it as an error because log.Println writes to stderr which Datadog treats as an error. 

### Description
We can either remove the log or we can make it `fmt.Printf` which Datadog will treat as normal log instead of an error. I chose the second approach here, but also open to removing the log completely. 